### PR TITLE
Fix bug ANSI color in git is not displayed correctly 

### DIFF
--- a/home/.exports
+++ b/home/.exports
@@ -28,10 +28,10 @@ readonly yellow
 export LESS_TERMCAP_md="${yellow}"
 
 # Don’t clear the screen after quitting a manual page.
-export MANPAGER='less -X'
+export MANPAGER='less -F -X -R'
 
 # Tells 'less' not to paginate if less than a page.
-export LESS="-F -X $LESS"
+export LESS="-F -X -R $LESS"
 
 # Avoid issues with `gpg` as installed via Homebrew.
 # https://stackoverflow.com/a/42265848/96656


### PR DESCRIPTION
Escaped output:

    ESC[33mcommit ebe1dbafdccb0122af5591a1fe00fa244f2bb98cESC[mESC[33m

https://stackoverflow.com/questions/8484167/ansi-color-in-git-is-not-displayed-correctly