### PR TITLE
Adds a tool for generating ecdsa keys

### DIFF
--- a/home/bin/ssh-keygen-ecdsa
+++ b/home/bin/ssh-keygen-ecdsa
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+LANG='en_US.UTF-8' \
+  LANGUAGE='en_US.UTF-8' \
+  ssh-keygen -o \
+  -t "ecdsa" \
+  -a "1024" \
+  -b "521" \
+  -C "ECDSA $(date +'%d-%b-%Y %H:%M:%S %Z') $(uname -n)"


### PR DESCRIPTION
For use, a key is selected that is comparable in strength to the
256-bit symmetric encryption key.

      +-----------+------------------------------+-------+---------+
      | Symmetric | Discrete Log (e.g., DSA, DH) |  RSA  |   ECC   |
      +-----------+------------------------------+-------+---------+
      |     80    |       L = 1024, N = 160      |  1024 | 160-223 |
      |           |                              |       |         |
      |    112    |       L = 2048, N = 256      |  2048 | 224-255 |
      |           |                              |       |         |
      |    128    |       L = 3072, N = 256      |  3072 | 256-383 |
      |           |                              |       |         |
      |    192    |       L = 7680, N = 384      |  7680 | 384-511 |
      |           |                              |       |         |
      |    256    |      L = 15360, N = 512      | 15360 |   512+  |
      +-----------+------------------------------+-------+---------+

https://tools.ietf.org/html/rfc5656#section-1
https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r4.pdf