### PR TITLE
Add git alias, what the heck was I just doing

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -151,6 +151,8 @@ brbl = !"git branch | grep -E backup/[0-9a-f]{7}/.*"
 brbd = !"git branch -d `git brbl`"
 brbD = !"git branch -D `git brbl`"
 
+wip = for-each-ref --sort='authordate:iso8601' --format=' %(color:green)%(authordate:relative)%09%(color:white)%(refname:short)' refs/heads
+
 [diff "bin"]
 
 # Use `hexdump` to diff binary files


### PR DESCRIPTION
Have you ever run git branch and still wasn’t sure what each one is for
and if it’s recent? Here’s a git alias, git wip, that displays your
branches and when you last changed them. It’s really useful for
remembering which one you were just working on, and which branches
probably should be deleted.

Edit your ~/.gitconfig file (or create one if you don’t have it) and
add the following lines. If you already have an alias section, add this
to the existing section:

The branches are sorted in descending order so that you will see the
most recent branches at the bottom. Just in case you have so many that
the output scrolls, you can still see the most recent branches. Not
that I would ever have so many old branches lying around or anything
that I’d need that…

    wip = for-each-ref --sort='authordate:iso8601' --format=' %(color:green)%(authordate:relative)%09%(color:white)%(refname:short)' refs/heads

https://carolynvanslyck.com/blog/2020/12/git-wip/