### PR TITLE
Add scheduled CI startup

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron:  '0 0 1 * *'
 
 jobs:
   static-analysis:


### PR DESCRIPTION
This is necessary for regular checking of scripts, and early detection
of errors that could accumulate due to updating of various tools and
software.