### PR TITLE
Fix the command shell type definition

### DIFF
--- a/home/.prompt
+++ b/home/.prompt
@@ -150,7 +150,7 @@ function prompt_git() {
   fi
 }
 
-if [[ "$(basename "$0")" == 'bash' ]]; then
+if [[ "$(basename "$0")" == 'bash' ]] || [[ -n "$BASH" ]]; then
   username_placeholder="\u"
   hostname_placeholder="\h"
   workdir_placeholder="\w"


### PR DESCRIPTION
This is necessary for a more successful definition of the command shell
used.