### PR TITLE
Configure the locale in the terminal

### DIFF
--- a/home/.exports
+++ b/home/.exports
@@ -21,7 +21,8 @@ export HISTCONTROL='ignoreboth'
 
 # Prefer US English and use UTF-8.
 export LANG='en_US.UTF-8'
-export LC_ALL='en_US.UTF-8'
+export LANGUAGE="$LANG:en_US:en"
+export LC_ALL=
 
 # Highlight section titles in manual pages.
 # shellcheck disable=SC2154


### PR DESCRIPTION
Configure the locale in the terminal

This is necessary to unify the design of translations on different
computers, so that you can see the output of commands and various text
prompts in the same form and in the same language. Russian Russian
language is chosen because it is widely used and it very rarely comes
across bad translations, unlike Russian, in Russian often comes across
a non-verbal translation, and in some places it breaks the user
experience due to the change of the text.

P. S. - `export LC_CTYPE='C'` it can fix some problems with built in
commands but it causes problems with entering Cyrillic characters.

```
xor at ant in
/var/folders/g4/kq_rtk_j64z3xhpy0q8pftl40000gn/T/tmp.htd7QPDM
❯ tr -dc '[:graph:]' < /dev/urandom | fold -w 40 | head -n5
tr: Illegal byte sequence
```

But this can be fixed, you just have to set the variable
`LC_CTYPE='C.UTF-8'` and it will work correctly with any
characters from UTF-8, but the essential problem is that
there is no such locale in macOS.

Similar problems:
https://stackoverflow.com/questions/7165108/in-os-x-lion-lang-is-not-set-to-utf-8-how-to-fix-it
https://github.com/microsoft/vscode/issues/7301
https://stackoverflow.com/questions/9991603/add-a-locale-in-mac-osx

P. P. S. Now not all problems are solved and I still can't use the tr
command properly I hope that when the time comes to deal with
localization again I will be able to solve this problem.