### PR TITLE
Fix git insteadOf settings

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -189,15 +189,11 @@ recurse = false
 
 [url "https://github.com/"]
 insteadOf = git://github.com/
-pushInsteadOf = git://github.com/
 [url "git@gitlab.com:"]
-insteadOf = https://gitlab.com/
 pushInsteadOf = https://gitlab.com/
 [url "git@github.com:"]
-insteadOf = https://github.com/
 pushInsteadOf = https://github.com/
 [url "git@bitbucket.org:"]
-insteadOf = https://bitbucket.org/
 pushInsteadOf = https://bitbucket.org/
 
 [include] ; https://git-scm.com/docs/git-config#_includes


### PR DESCRIPTION
This solves several problems:
* The first is that it is not always convenient to download all
projects from github via ssh, at times the keys are not configured in
the code, this is inconvenient.

* The second reason is the incorrect use of the setting itself, you do
not need to use pushInsteadOf and insteadOf together.