### PR TITLE
Make ci fast again

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron:  '0 0 1 * *'
+  - cron: '0 0 1 * *'
 
 jobs:
   static-analysis:
@@ -40,5 +40,3 @@ jobs:
     - uses: actions/checkout@v2
     - name: Checking the installation of dotfiles on ${{ matrix.os }}
       run: make install
-    - name: Checking the installation of software on ${{ matrix.os }}
-      run: make install-software

--- a/.github/workflows/software-continuous-integration.yml
+++ b/.github/workflows/software-continuous-integration.yml
@@ -1,0 +1,28 @@
+name: Software Continuous Integration
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - 'scripts/make-install-software*.sh'
+  pull_request:
+    branches: [ main ]
+    paths:
+    - 'scripts/make-install-software*.sh'
+  schedule:
+  - cron: '0 0 1 * *'
+
+jobs:
+  check-installer:
+    name: Checking the software installation
+    strategy:
+      matrix:
+        os:
+        - 'ubuntu-18.04'
+        - 'ubuntu-20.04'
+        - 'macos-10.15'
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checking the installation of software on ${{ matrix.os }}
+      run: make install-software


### PR DESCRIPTION
Software installation checks are very long for macOS, so now I decided
to put them in a separate task, while in one general, if there are
problems with it when changing files for linux, I will try to divide
them into separate workflows.