### PR TITLE
Make a local gitconfig for computers

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -197,4 +197,12 @@ pushInsteadOf = https://github.com/
 pushInsteadOf = https://bitbucket.org/
 
 [include] ; https://git-scm.com/docs/git-config#_includes
-path = ~/.gituserconfig ; Include local user settings, for example `user.name` and `user.email`.
+# `~/.gitconfig.local` it will store the global settings, but unlike
+# `~/.gitconfig` only those that are connected to a specific computer so-as
+# through a standard file, the settings are synchronized the same on all
+# computers that I usually use.
+# For example: `user.name` `user.email` `user.signingkey` etc...
+#
+# To add global parameters, use: git config --file ~/.gitconfig.local
+# For example: git config --file ~/.gitconfig.local user.name Lucky
+path = ~/.gitconfig.local


### PR DESCRIPTION
`~/.gitconfig.local` it will store the global settings, but unlike
`~/.gitconfig` only those that are connected to a specific computer
so-as through a standard file, the settings are synchronized the same
on all computers that I usually use.
For example: `user.name` `user.email` `user.signingkey` etc...

To fix an existing file, use `~/.gituserconfig`:

```
mv ~/.gituserconfig ~/.gitconfig.local
```

Links:
https://agateau.com/2015/splitting-your-gitconfig
https://git-scm.com/docs/git-config#_includes
https://blog.thomasheartman.com/posts/modularizing-your-git-config-with-conditional-includes
https://itnext.io/setup-git-with-multiple-configs-9b4111d6928c