### PR TITLE
Fix LANGUAGE env variable

### DIFF
--- a/home/.exports
+++ b/home/.exports
@@ -21,7 +21,7 @@ export HISTCONTROL='ignoreboth'
 
 # Prefer US English and use UTF-8.
 export LANG='en_US.UTF-8'
-export LANGUAGE="$LANG:en_US:en"
+export LANGUAGE="${LANG}:en_US:en"
 export LC_ALL=
 
 # Highlight section titles in manual pages.


### PR DESCRIPTION
Due to the special format of the string, it turned out like a standard
truncation of the LANGUAGE string, this led to not entirely correct
eating. Now I have fixed this error, but it remains a strange question
why shellcheck did not find this problem.

Expected: 'en_US.UTF-8:en_US:en'
Actual: 'UTF-8n_US:en'