### PR TITLE
Fix the error with including a non-existent file

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -81,8 +81,9 @@ plugins=(
   tig
 )
 
-# shellcheck disable=SC1090
-source "$ZSH/oh-my-zsh.sh"
+if [ -f "$ZSH/oh-my-zsh.sh" ]; then
+  source "$ZSH/oh-my-zsh.sh"
+fi
 
 # User configuration
 


### PR DESCRIPTION
Not all machines have oh-my-zsh installed, since not all machines need
it, and conditional loading is added to avoid errors.

```
xor at ant in ~/work/dotfiles on  main [$]
❯ zsh
/home/xor/.zshrc:source:85: no such file or directory: /home/xor/.oh-my-zsh/oh-my-zsh.sh
```