### PR TITLE
Add aliases for creating dates compatible with file name

### DIFF
--- a/home/.aliases
+++ b/home/.aliases
@@ -59,3 +59,7 @@ top30() {
   history | awk "${pattern}" | awk 'BEGIN {FS="|"} {print $1}' | sort |
     uniq -c | sort -rn | head -30
 }
+
+alias fdate='date +"%Y-%m-%dT%H%M%S%z"'
+alias fdateu='date -u +"%Y-%m-%dT%H%M%S%z"'
+alias fdatez='date -u +"%Y-%m-%dT%H%M%SZ"'


### PR DESCRIPTION
This will allow you to quickly generate dates in a format compatible
with file names. This is often used when you need to add a date to the
file name, for example, to sort or mark the time of creation, receipt.