### PR TITLE
Fix loading child configurations from config.d

### DIFF
--- a/home/.ssh/config
+++ b/home/.ssh/config
@@ -48,16 +48,6 @@ Host *
   # Default is "no"
   AddKeysToAgent yes
 
-Host github.com
-  HostName github.com
-  Port 22
-  User git
-
-Host gitlab.com
-  HostName gitlab.com
-  Port 22
-  User git
-
 # This is necessary to divide the ssh configuration into separate files, which
 # will allow you to separate the parameters that are fixed in the dotfiles
 # repository, files that are used for personal purposes and files that are used

--- a/home/.ssh/config.d/00-github.com.conf
+++ b/home/.ssh/config.d/00-github.com.conf
@@ -1,0 +1,4 @@
+Host github.com
+  HostName github.com
+  Port 22
+  User git

--- a/home/.ssh/config.d/00-gitlab.com.conf
+++ b/home/.ssh/config.d/00-gitlab.com.conf
@@ -1,0 +1,4 @@
+Host gitlab.com
+  HostName gitlab.com
+  Port 22
+  User git


### PR DESCRIPTION
I don't know why, but defining specific hosts before the 'Include config.d/*.conf' option breaks config loading.